### PR TITLE
Add rotating log file

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -60,8 +60,8 @@ FUNCIONAMIENTO INTERNO
 LOGS PERSONALIZADOS
 ===================
 
-El activador registra eventos importantes en el archivo:
-  ./activador.log
+El activador registra eventos importantes en el archivo rotativo:
+  ./log.txt (tamaño máximo 3 MB)
 
 Ejemplos de entradas:
   - Inicio de Frigate


### PR DESCRIPTION
## Summary
- rotate log output to `log.txt` so it does not exceed ~3 MB
- update docs to mention new `log.txt` file

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68828f9eb1a08332aca0b8b8aaa6b38c