### PR TITLE
Fix logger duplication and update monitor interval

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ app = Flask(__name__)
 # Configuración
 CONTAINER_NAME = "frigate"
 FRIGATE_URL = "http://frigate.gabo.ar"
-CHECK_INTERVAL = 60  # cada 1 min se evalúa la actividad
+CHECK_INTERVAL = 300  # cada 5 min se evalúa la actividad
 INACTIVIDAD_MINUTOS = 10
 LOG_FILE = "log.txt"
 monitor_activo = False
@@ -24,12 +24,6 @@ handler = RotatingFileHandler(LOG_FILE, maxBytes=3 * 1024 * 1024, backupCount=1)
 handler.setFormatter(logging.Formatter('[%(asctime)s] %(message)s'))
 logger.addHandler(handler)
 
-# Configurar registro de eventos con rotación
-logger = logging.getLogger("activador")
-logger.setLevel(logging.INFO)
-handler = RotatingFileHandler(LOG_FILE, maxBytes=3 * 1024 * 1024, backupCount=1)
-handler.setFormatter(logging.Formatter('[%(asctime)s] %(message)s'))
-logger.addHandler(handler)
 
 
 def log_event(mensaje):

--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,7 @@ FUNCIONAMIENTO INTERNO
    - Mientras tanto, muestra la pantalla `loading.html`.
    - Cuando el contenedor está listo, redirige al usuario al sitio real.
 4. Luego inicia un proceso de monitoreo en segundo plano:
-  - Cada 1 minuto chequea los últimos logs del contenedor.
+  - Cada 5 minutos chequea los últimos logs del contenedor.
   - Espera al menos 10 minutos desde el arranque antes de evaluar la actividad.
   - Si no se detectan peticiones GET en ese período, detiene el contenedor automáticamente.
    - Finaliza el monitoreo (y no lo reinicia, salvo que se vuelva a acceder a `/`).


### PR DESCRIPTION
## Summary
- clean up duplicate logger setup
- monitor Frigate container every 5 minutes
- update README to match new interval

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6882c9fcfb0c8332942559e9502cf050