### PR TITLE
Add simple login page

### DIFF
--- a/login.html
+++ b/login.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Acceso</title>
+  <style>
+    body {
+      margin: 0;
+      font-family: Arial, sans-serif;
+      background: #f4f4f4;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      height: 100vh;
+    }
+    form {
+      background: white;
+      padding: 20px;
+      border-radius: 5px;
+      box-shadow: 0 2px 5px rgba(0,0,0,0.3);
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+    input {
+      padding: 8px;
+      font-size: 16px;
+    }
+    button {
+      padding: 8px;
+      font-size: 16px;
+    }
+    .error {
+      color: red;
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+  <form method="post">
+    <input type="text" name="username" placeholder="Usuario" required>
+    <input type="password" name="password" placeholder="Contraseña" required>
+    <button type="submit">Ingresar</button>
+    <div class="error" id="err"></div>
+  </form>
+  <script>
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('error')) {
+      document.getElementById('err').textContent = 'Credenciales incorrectas';
+    }
+  </script>
+</body>
+</html>

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-from flask import Flask, send_from_directory, redirect, jsonify
+from flask import Flask, send_from_directory, redirect, jsonify, request, session
 import subprocess
 import threading
 import time
@@ -14,6 +14,12 @@ FRIGATE_URL = "http://frigate.gabo.ar"
 CHECK_INTERVAL = 300  # cada 5 min se evalúa la actividad
 INACTIVIDAD_MINUTOS = 10
 LOG_FILE = "log.txt"
+
+# Credenciales de acceso
+LOGIN_USER = "taller"
+LOGIN_PASS = "gabo5248"
+
+app.secret_key = os.environ.get("SECRET_KEY", "cambie_esto")
 monitor_activo = False
 inicio_monitor = 0.0
 
@@ -117,7 +123,23 @@ def monitor_usage():
             break
 
 
-@app.route("/")
+@app.route("/", methods=["GET", "POST"])
+def login():
+    if request.method == "POST":
+        user = request.form.get("username")
+        pw = request.form.get("password")
+        if user == LOGIN_USER and pw == LOGIN_PASS:
+            session["logged_in"] = True
+            return redirect("/activar")
+        return redirect("/?error=1")
+
+    if session.get("logged_in"):
+        return redirect("/activar")
+
+    return send_from_directory(".", "login.html")
+
+
+@app.route("/activar")
 def activar():
     def iniciar_y_esperar():
         try:

--- a/readme.md
+++ b/readme.md
@@ -3,8 +3,11 @@ FRIGATE ACTIVADOR - DOCUMENTACIÓN Y USO
 
 Este servicio permite iniciar el contenedor Docker de Frigate bajo demanda 
 cuando un usuario accede al sitio, mostrando una pantalla de espera ("loading") 
-hasta que el contenedor esté listo (estado healthy). 
-Luego, redirige automáticamente al sitio real. 
+hasta que el contenedor esté listo (estado healthy).
+Luego, redirige automáticamente al sitio real.
+
+Al acceder a la raíz del servicio se presenta una pantalla de login. Solo se
+permite el ingreso con el usuario **taller** y la contraseña **gabo5248**.
 
 Además, monitorea la actividad del usuario en los logs: 
 si pasan más de 10 minutos sin actividad (peticiones GET), 
@@ -62,13 +65,14 @@ FUNCIONAMIENTO INTERNO
 ======================
 
 1. El usuario accede a `http://frigate.gabo.ar` (redirigido por Nginx Proxy Manager).
-2. Llega al servicio Flask del activador en el puerto 5544.
-3. El activador:
+2. Se muestra el formulario de login. Si las credenciales son válidas, se continúa.
+3. Llega al servicio Flask del activador en el puerto 5544.
+4. El activador:
    - Inicia el contenedor `frigate` (si no está corriendo).
    - Espera a que esté en estado `healthy` leyendo su estado con `docker inspect`.
    - Mientras tanto, muestra la pantalla `loading.html`.
    - Cuando el contenedor está listo, redirige al usuario al sitio real.
-4. Luego inicia un proceso de monitoreo en segundo plano:
+5. Luego inicia un proceso de monitoreo en segundo plano:
   - Cada 5 minutos chequea los últimos logs del contenedor.
   - Espera al menos 10 minutos desde el arranque antes de evaluar la actividad.
   - Si no se detectan peticiones GET en ese período, detiene el contenedor automáticamente.


### PR DESCRIPTION
## Summary
- add login credentials constants and Flask session secret
- add login route and page
- update activation route path
- document login flow in README

## Testing
- `python3 -m py_compile main.py`
- `pip install flask`
- `python3 main.py` (fails if Flask missing, so installed)


------
https://chatgpt.com/codex/tasks/task_e_6883080c308883329ddebab0b9220a21