### PR TITLE
Add Makefile utilities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,59 @@
+SERVICE=frigate-activador.service
+CONTAINER=frigate
+
+.PHONY: start stop restart status active logs logsf logtxt logs-fri logs-fri-f help push
+
+## Iniciar el servicio via systemd
+start:
+	sudo systemctl start $(SERVICE)
+
+## Detener el servicio
+stop:
+	sudo systemctl stop $(SERVICE)
+
+## Reiniciar el servicio
+restart:
+	sudo systemctl restart $(SERVICE)
+
+## Mostrar estado detallado del servicio
+status:
+	systemctl status $(SERVICE)
+
+## Comprobar si el servicio esta activo
+active:
+	systemctl is-active $(SERVICE)
+
+## Mostrar logs completos del servicio
+logs:
+	journalctl -u $(SERVICE)
+
+## Seguir logs en tiempo real del servicio
+logsf:
+	journalctl -u $(SERVICE) -f
+
+## Seguir el archivo log.txt generado por el activador
+logtxt:
+	tail -f log.txt
+
+## Ver logs del contenedor Frigate
+logs-fri:
+	docker logs $(CONTAINER)
+
+## Seguir los logs del contenedor Frigate en tiempo real
+logs-fri-f:
+	docker logs -f $(CONTAINER)
+
+## Realizar add, commit y push con un mensaje
+push:
+	@$(eval MSG := $(filter-out $@,$(MAKECMDGOALS)))
+	@if [ -z "$(MSG)" ]; then \
+echo 'Uso: make push "mensaje de commit"'; \
+exit 1; \
+fi
+	git add .
+	git commit -m "$(MSG)"
+	git push
+
+## Mostrar esta ayuda
+help:
+	@grep -E '^[a-zA-Z_-]+:' Makefile | sed 's/^/ - /'

--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,23 @@ USO GENERAL
   journalctl -u frigate-activador.service
 
 
+COMANDOS MAKE
+=============
+
+Para administrar el servicio de forma rapida se puede usar el Makefile incluido. Las tareas principales son:
+
+  make start       - inicia el servicio
+  make stop        - detiene el servicio
+  make restart     - reinicia el servicio
+  make status      - muestra el estado
+  make active      - indica si esta activo
+  make logs        - muestra los logs completos
+  make logsf       - sigue los logs en tiempo real
+  make logtxt      - tail del archivo log.txt
+  make logs-fri    - logs del contenedor Frigate
+  make logs-fri-f  - logs del contenedor Frigate en tiempo real
+  make push "mensaje" - add, commit y push
+  make help        - lista todas las tareas
 --------------------------------------------------
 FUNCIONAMIENTO INTERNO
 ======================


### PR DESCRIPTION
## Summary
- add Makefile with shortcuts for controlling the service and container
- document Makefile usage in README

## Testing
- `python3 -m py_compile main.py`
- `make help`


------
https://chatgpt.com/codex/tasks/task_e_6883af5eb5088332affca53385350099