### PR TITLE
Esperar a que el contenedor de Frigate esté saludable

### DIFF
--- a/funciones.py
+++ b/funciones.py
@@ -69,14 +69,16 @@ def container_ready(container_name):
             "docker", "inspect", "--format",
             "{{.State.Health.Status}}", container_name
         ], text=True).strip()
-        if output == "healthy":
-            return True
+        if output and output != "<no value>":
+            return output == "healthy"
     except FileNotFoundError:
         log_event("Comando 'docker' no encontrado al verificar estado")
+        return False
     except subprocess.CalledProcessError:
         pass
     except Exception as e:
         log_event(f"Error verificando estado del contenedor: {e}")
+        return False
 
     # Como fallback, consideramos listo si simplemente está corriendo
     return container_running(container_name)


### PR DESCRIPTION
## Resumen
- Ajustar `container_ready` para devolver *False* mientras el contenedor no esté saludable.
- Evitar redirigir al usuario antes de que Frigate termine de inicializarse.

## Testing
- `python -m py_compile funciones.py rutas.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_6899ead50c8483328ea492d43f92f0e2